### PR TITLE
Handle invalid repository path

### DIFF
--- a/code_historian/cli.py
+++ b/code_historian/cli.py
@@ -1,4 +1,7 @@
 import argparse
+import sys
+import git
+
 from .analyzer import analyze_repository
 from .reporter import generate_reports
 
@@ -9,7 +12,12 @@ def main() -> None:
     parser.add_argument('--output-dir', default='.', help='Directory for reports')
     args = parser.parse_args()
 
-    data = analyze_repository(args.repo_path)
+    try:
+        data = analyze_repository(args.repo_path)
+    except (git.exc.InvalidGitRepositoryError, FileNotFoundError):
+        print(f"Error: {args.repo_path} is not a valid Git repository.", file=sys.stderr)
+        sys.exit(1)
+
     generate_reports(data, args.output_dir)
 
 


### PR DESCRIPTION
## Summary
- handle invalid repository path in CLI with user-friendly message and non-zero exit

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688db924869c8333a870197e2ebc997c