### PR TITLE
feat: ignore common directories when scanning todos

### DIFF
--- a/code_historian/analyzer.py
+++ b/code_historian/analyzer.py
@@ -47,7 +47,10 @@ def extract_changed_lines(patch: str) -> Set[int]:
 
 def scan_todos(repo_path: str) -> List[Dict[str, str]]:
     todos = []
-    for root, _, files in os.walk(repo_path):
+    skip_dirs = {".git", "venv", "node_modules", ".venv", "__pycache__"}
+    for root, dirs, files in os.walk(repo_path):
+        # prune directories we don't want to scan
+        dirs[:] = [d for d in dirs if d not in skip_dirs and not d.startswith('.')]
         for fname in files:
             if fname.endswith('.py'):
                 full = os.path.join(root, fname)


### PR DESCRIPTION
## Summary
- ignore common directories like `.git`, `venv`, and `node_modules` when searching for TODO comments

## Testing
- `pytest -q`
- `python -m py_compile code_historian/analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_688dc266db84833382c2b3828ebfcfe0