### PR TITLE
chore: add Code Historian report

### DIFF
--- a/reports/historian_report.json
+++ b/reports/historian_report.json
@@ -1,0 +1,73 @@
+{
+  "high_churn_files": [
+    {
+      "file": "code_historian/reporter.py",
+      "commit_count": 6
+    },
+    {
+      "file": "code_historian/analyzer.py",
+      "commit_count": 4
+    },
+    {
+      "file": "code_historian/cli.py",
+      "commit_count": 4
+    },
+    {
+      "file": "README.md",
+      "commit_count": 3
+    },
+    {
+      "file": ".gitignore",
+      "commit_count": 2
+    },
+    {
+      "file": "code_historian/__init__.py",
+      "commit_count": 2
+    }
+  ],
+  "high_churn_functions": [
+    {
+      "file": "code_historian/analyzer.py",
+      "function": "scan_todos",
+      "commit_count": 4
+    },
+    {
+      "file": "code_historian/reporter.py",
+      "function": "generate_reports",
+      "commit_count": 6
+    },
+    {
+      "file": "code_historian/cli.py",
+      "function": "main",
+      "commit_count": 4
+    }
+  ],
+  "todos": [
+    {
+      "file": "code_historian/analyzer.py",
+      "line": 9,
+      "text": "TODO_PATTERN = re.compile(r\"#.*\\b(TODO|FIXME)\\b\", re.IGNORECASE)"
+    }
+  ],
+  "test_failures": [],
+  "temporal_churn": {
+    "code_historian/analyzer.py": {
+      "2025-08": 4
+    },
+    "code_historian/reporter.py": {
+      "2025-08": 6
+    },
+    "code_historian/cli.py": {
+      "2025-08": 4
+    },
+    ".gitignore": {
+      "2025-08": 2
+    },
+    "README.md": {
+      "2025-08": 3
+    },
+    "code_historian/__init__.py": {
+      "2025-08": 2
+    }
+  }
+}

--- a/reports/historian_report.md
+++ b/reports/historian_report.md
@@ -1,0 +1,59 @@
+# Code Historian Report
+## High Churn Files
+| File | Commit Count |
+| --- | ---: |
+| code_historian/reporter.py | 6 |
+| code_historian/analyzer.py | 4 |
+| code_historian/cli.py | 4 |
+| README.md | 3 |
+| .gitignore | 2 |
+| code_historian/__init__.py | 2 |
+
+## Functions with 3+ Changes
+| File | Function | Commit Count |
+| --- | --- | ---: |
+| code_historian/analyzer.py | scan_todos | 4 |
+| code_historian/reporter.py | generate_reports | 6 |
+| code_historian/cli.py | main | 4 |
+
+## TODOs / FIXMEs
+| File | Line | Text |
+| --- | ---: | --- |
+| code_historian/analyzer.py | 9 | TODO_PATTERN = re.compile(r"#.*\b(TODO|FIXME)\b", re.IGNORECASE) |
+
+## Test Failures
+No test failures found.
+
+## Temporal Churn
+File: code_historian/reporter.py
+Monthly Churn: ▇
+Top Month: 2025-08 (6 commits)
+
+File: code_historian/analyzer.py
+Monthly Churn: ▇
+Top Month: 2025-08 (4 commits)
+
+File: code_historian/cli.py
+Monthly Churn: ▇
+Top Month: 2025-08 (4 commits)
+
+File: README.md
+Monthly Churn: ▇
+Top Month: 2025-08 (3 commits)
+
+File: .gitignore
+Monthly Churn: ▇
+Top Month: 2025-08 (2 commits)
+
+File: code_historian/__init__.py
+Monthly Churn: ▇
+Top Month: 2025-08 (2 commits)
+
+
+## Summary
+- code_historian/reporter.py changed 6 times. Functions changed: generate_reports (6).
+- code_historian/analyzer.py changed 4 times. Functions changed: scan_todos (4).
+- code_historian/cli.py changed 4 times. Functions changed: main (4).
+- README.md changed 3 times.
+- .gitignore changed 2 times.
+- code_historian/__init__.py changed 2 times.


### PR DESCRIPTION
## Summary
- capture repository history with Code Historian

## Testing
- `pytest`
- `python -m py_compile code_historian/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688dc45c7aa88333bdba263b3c4f15a6