### PR TITLE
Add risk scoring and evolution engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.aether/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ python -m code_historian.cli /path/to/repo
 ```
 
 This command generates `historian_report.json` and `historian_report.md` in the
-current directory.
+current directory. Risk scores and evolution suggestions are also produced and
+all artifacts are saved in a persistent `.aether/` directory for future runs.
 
 The report highlights high-churn files, frequently edited functions, unresolved
 TODO/FIXME comments, test failures, and includes monthly churn timelines for

--- a/code_historian/analyzer.py
+++ b/code_historian/analyzer.py
@@ -115,7 +115,14 @@ def analyze_repository(repo_path: str) -> Dict[str, List]:
         if len(commits) >= 3
     ]
 
+    function_edit_counts: Dict[str, int] = defaultdict(int)
+    for (f, _func), commits in function_commits.items():
+        function_edit_counts[f] += len(commits)
+
     todos = scan_todos(repo.working_tree_dir)
+    todo_counts: Dict[str, int] = defaultdict(int)
+    for t in todos:
+        todo_counts[t['file']] += 1
 
     temporal_churn_dict = {f: dict(months) for f, months in temporal_churn.items()}
 
@@ -125,4 +132,7 @@ def analyze_repository(repo_path: str) -> Dict[str, List]:
         'todos': todos,
         'test_failures': test_failures,
         'temporal_churn': temporal_churn_dict,
+        'file_commit_counts': dict(file_commit_counts),
+        'function_edit_counts': dict(function_edit_counts),
+        'todo_counts': dict(todo_counts),
     }

--- a/code_historian/cli.py
+++ b/code_historian/cli.py
@@ -3,6 +3,8 @@ import sys
 import git
 
 from .analyzer import analyze_repository
+from .evolution import compute_risk_map, generate_evolution_log
+from .memory import save_memory
 from .reporter import generate_reports
 
 
@@ -18,7 +20,11 @@ def main() -> None:
         print(f"Error: {args.repo_path} is not a valid Git repository.", file=sys.stderr)
         sys.exit(1)
 
+    risk_map = compute_risk_map(args.repo_path, data)
+    evolution_log = generate_evolution_log(risk_map, data['todos'])
+
     generate_reports(data, args.output_dir)
+    save_memory(args.repo_path, args.output_dir, evolution_log, risk_map)
 
 
 if __name__ == '__main__':

--- a/code_historian/evolution.py
+++ b/code_historian/evolution.py
@@ -1,0 +1,65 @@
+import os
+from typing import Any, Dict, List
+
+from git import Repo
+
+
+def compute_risk_map(repo_path: str, data: Dict[str, Any]) -> Dict[str, Dict[str, float]]:
+    """Assign a risk score to each Python file in the repository."""
+    repo = Repo(repo_path)
+    files = [f for f in repo.git.ls_files().splitlines() if f.endswith('.py')]
+    commit_counts = data.get('file_commit_counts', {})
+    function_counts = data.get('function_edit_counts', {})
+    todo_counts = data.get('todo_counts', {})
+
+    max_commit = max(commit_counts.values(), default=1)
+    max_function = max(function_counts.values(), default=1)
+    max_todo = max(todo_counts.values(), default=1)
+
+    risk_map: Dict[str, Dict[str, float]] = {}
+    for f in files:
+        commit_factor = commit_counts.get(f, 0) / max_commit if max_commit else 0.0
+        function_factor = function_counts.get(f, 0) / max_function if max_function else 0.0
+        todo_factor = todo_counts.get(f, 0) / max_todo if max_todo else 0.0
+        base = os.path.basename(f).replace('.py', '')
+        has_tests = any(base in os.path.basename(tf) and 'test' in os.path.basename(tf) for tf in files)
+        test_factor = 0.0 if has_tests else 1.0
+        risk = (commit_factor + function_factor + todo_factor + test_factor) / 4.0
+        risk_map[f] = {
+            'commit_factor': round(commit_factor, 3),
+            'function_factor': round(function_factor, 3),
+            'todo_factor': round(todo_factor, 3),
+            'test_factor': test_factor,
+            'risk': round(risk, 3),
+        }
+    return risk_map
+
+
+def generate_evolution_log(risk_map: Dict[str, Dict[str, float]], todos: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Produce evolution suggestions and prioritized TODOs."""
+    suggestions: List[Dict[str, Any]] = []
+    for path, metrics in risk_map.items():
+        if metrics['risk'] >= 0.6:
+            reasons = []
+            if metrics['test_factor'] > 0:
+                reasons.append('missing tests')
+            if metrics['commit_factor'] > 0.5:
+                reasons.append('high churn')
+            if metrics['todo_factor'] > 0.5:
+                reasons.append('many TODOs')
+            if metrics['function_factor'] > 0.5:
+                reasons.append('frequent function edits')
+            reason_text = ', '.join(reasons) if reasons else 'elevated risk'
+            suggestions.append({'file': path, 'risk': metrics['risk'], 'reason': reason_text})
+
+    todo_priorities: List[Dict[str, Any]] = []
+    for todo in todos:
+        score = risk_map.get(todo['file'], {}).get('risk', 0.0)
+        todo_priorities.append({**todo, 'risk': score})
+    todo_priorities.sort(key=lambda x: x['risk'], reverse=True)
+
+    return {
+        'suggestions': suggestions,
+        'todo_priorities': todo_priorities,
+    }
+

--- a/code_historian/memory.py
+++ b/code_historian/memory.py
@@ -1,0 +1,27 @@
+import json
+import os
+import shutil
+from typing import Any, Dict
+
+
+def save_memory(repo_path: str, report_dir: str, evolution_log: Dict[str, Any], risk_map: Dict[str, Dict[str, float]]) -> None:
+    """Persist historian outputs and evolution data to .aether directory."""
+    memory_dir = os.path.join(repo_path, '.aether')
+    os.makedirs(memory_dir, exist_ok=True)
+
+    src_json = os.path.join(report_dir, 'historian_report.json')
+    src_md = os.path.join(report_dir, 'historian_report.md')
+    dst_json = os.path.join(memory_dir, 'historian_report.json')
+    dst_md = os.path.join(memory_dir, 'historian_report.md')
+
+    if os.path.abspath(src_json) != os.path.abspath(dst_json):
+        if os.path.exists(src_json):
+            shutil.copy(src_json, dst_json)
+    if os.path.abspath(src_md) != os.path.abspath(dst_md):
+        if os.path.exists(src_md):
+            shutil.copy(src_md, dst_md)
+
+    with open(os.path.join(memory_dir, 'evolution_log.json'), 'w', encoding='utf-8') as ef:
+        json.dump(evolution_log, ef, indent=2)
+    with open(os.path.join(memory_dir, 'risk_map.json'), 'w', encoding='utf-8') as rf:
+        json.dump(risk_map, rf, indent=2)


### PR DESCRIPTION
## Summary
- score file risk by churn, TODO density and missing tests
- generate evolution suggestions and TODO priorities
- persist historian outputs and evolution data to `.aether`

## Testing
- `python -m code_historian.cli . --output-dir reports`


------
https://chatgpt.com/codex/tasks/task_e_688dcacae1f08333b5e8d590db3516d1