### PR TITLE
feat: scaffold rewriter module

### DIFF
--- a/aether/rewriter.py
+++ b/aether/rewriter.py
@@ -1,0 +1,135 @@
+"""Perform automated code rewrites based on risk suggestions.
+
+This module parses a ``risk_map.json`` file and produces mutated copies of
+high‑risk source files.  Each rewrite is written under ``__aether_mutation__``
+so the original sources remain untouched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import ast
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .patch_writer import load_risk_map
+
+
+class Confidence(str, Enum):
+    """Confidence levels assigned to mutations."""
+
+    HIGH = "HIGH_CONFIDENCE"
+    LOW = "LOW_CONFIDENCE"
+
+
+@dataclass
+class RewriteResult:
+    """Outcome of a rewrite operation."""
+
+    original: Path
+    mutated: Path
+    strategy: str
+    confidence: Confidence
+
+
+def select_strategy(entry: Dict[str, Any]) -> Optional[str]:
+    """Pick a rewrite strategy based on ``entry`` hints.
+
+    The function looks at the ``suggestions`` field for keywords and returns a
+    strategy identifier or ``None`` if no strategy matches.
+    """
+
+    suggestions = " ".join(entry.get("suggestions", [])).lower()
+    if "docstring" in suggestions:
+        return "insert_docstring"
+    if "todo" in suggestions:
+        return "complete_todo"
+    if "split" in suggestions:
+        return "split_function"
+    return None
+
+
+def _insert_docstring(source: str) -> str:
+    """Insert placeholder docstrings into functions lacking them."""
+
+    tree = ast.parse(source)
+    lines = source.splitlines()
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            if not ast.get_docstring(node):
+                indent = " " * (node.col_offset + 4)
+                doc = f'{indent}"""TODO: documented by AETHER."""  # [AETHER_REWRITE]'
+                insert_line = node.body[0].lineno - 1
+                lines.insert(insert_line, doc)
+                break
+    return "\n".join(lines) + "\n"
+
+
+def _complete_todo(source: str) -> str:
+    """Mark TODO comments as handled by AETHER."""
+
+    replaced: List[str] = []
+    for line in source.splitlines():
+        if "TODO" in line:
+            line = line.replace("TODO", "TODO handled by AETHER")
+        replaced.append(line)
+    return "\n".join(replaced) + "\n"
+
+
+def rewrite_file(entry: Dict[str, Any], project_root: Path) -> Optional[RewriteResult]:
+    """Apply a rewrite strategy to the file described by ``entry``."""
+
+    strategy = select_strategy(entry)
+    if not strategy:
+        return None
+
+    src_path = project_root / entry.get("filename", "")
+    if not src_path.exists():
+        return None
+
+    with src_path.open("r", encoding="utf-8") as fh:
+        original = fh.read()
+
+    if strategy == "insert_docstring":
+        mutated_src = _insert_docstring(original)
+    elif strategy == "complete_todo":
+        mutated_src = _complete_todo(original)
+    else:
+        mutated_src = original
+
+    mut_path = project_root / "__aether_mutation__" / entry.get("filename", "")
+    mut_path.parent.mkdir(parents=True, exist_ok=True)
+    with mut_path.open("w", encoding="utf-8") as fh:
+        fh.write(mutated_src)
+
+    risk = float(entry.get("risk_score", 0))
+    confidence = Confidence.HIGH if risk > 0.85 else Confidence.LOW
+
+    return RewriteResult(src_path, mut_path, strategy, confidence)
+
+
+def rewrite_from_risk_map(
+    risk_map_path: Path, project_root: Path, *, threshold: float = 0.7
+) -> List[RewriteResult]:
+    """Run rewrites for all qualifying entries in ``risk_map_path``."""
+
+    entries = load_risk_map(risk_map_path)
+    results: List[RewriteResult] = []
+    for entry in entries:
+        if float(entry.get("risk_score", 0)) < threshold:
+            continue
+        res = rewrite_file(entry, project_root)
+        if res:
+            results.append(res)
+    return results
+
+
+__all__ = [
+    "RewriteResult",
+    "Confidence",
+    "select_strategy",
+    "rewrite_file",
+    "rewrite_from_risk_map",
+]

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from aether.rewriter import Confidence, rewrite_from_risk_map
+
+
+def test_docstring_insertion(tmp_path: Path) -> None:
+    source = "def foo(x):\n    # TODO\n    return x\n"
+    module = tmp_path / "module.py"
+    module.write_text(source)
+
+    risk_map = tmp_path / "risk_map.json"
+    risk_map.write_text(
+        '[{"filename": "module.py", "risk_score": 0.9, "suggestions": ["add docstring"]}]'
+    )
+
+    results = rewrite_from_risk_map(risk_map, tmp_path, threshold=0.5)
+    assert len(results) == 1
+
+    mutated = tmp_path / "__aether_mutation__" / "module.py"
+    assert mutated.exists()
+    content = mutated.read_text()
+    assert '"""TODO: documented by AETHER."""' in content
+    # Ensure the original file is untouched
+    assert module.read_text() == source
+    assert results[0].confidence is Confidence.HIGH


### PR DESCRIPTION
## Summary
- add `aether.rewriter` to mutate high-risk files into a safe `__aether_mutation__` folder
- support simple rewrite strategies like docstring insertion and TODO completion with confidence scores
- test rewriter behaviour on docstring insertion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dfedd09148333b30a430a7c6bf21e