### PR TITLE
Add semantic code context parser

### DIFF
--- a/aether/code_context.py
+++ b/aether/code_context.py
@@ -1,0 +1,91 @@
+"""Extract lightweight semantic context from Python files.
+
+This module parses Python source files to build a minimal mapping of
+high‑level semantics for each file.  For every module the top‑level
+docstring is recorded as a short summary and information about declared
+functions is gathered.  Function context includes its docstring, a list
+of called functions and the number of source lines the function spans.
+
+The resulting mapping can be written to ``.aether/context_map.json``
+where it can be consumed by other AETHER components.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+def _called_functions(node: ast.AST) -> List[str]:
+    """Return sorted unique names of functions called within ``node``."""
+    calls = set()
+    for n in ast.walk(node):
+        if isinstance(n, ast.Call):
+            func = n.func
+            if isinstance(func, ast.Name):
+                calls.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                calls.add(func.attr)
+    return sorted(calls)
+
+
+def extract_file_context(path: Path) -> Dict[str, object]:
+    """Extract semantic context information from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Location of the Python source file to analyse.
+
+    Returns
+    -------
+    dict
+        Mapping containing a ``summary`` of the module and metadata for
+        each function definition found.
+    """
+
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    doc = ast.get_docstring(tree) or ""
+    summary = doc.strip().splitlines()[0] if doc else ""
+
+    functions: Dict[str, Dict[str, object]] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            func_doc = ast.get_docstring(node) or ""
+            lines = getattr(node, "end_lineno", node.lineno) - node.lineno + 1
+            functions[node.name] = {
+                "docstring": func_doc.strip(),
+                "calls": _called_functions(node),
+                "lines": lines,
+            }
+
+    return {"summary": summary, "functions": functions}
+
+
+def build_context_map(root: Path, *, output_path: Optional[Path] = None) -> Dict[str, object]:
+    """Build a context map for all ``*.py`` files under ``root``.
+
+    The map is also written to ``output_path`` which defaults to
+    ``root/.aether/context_map.json``.
+    """
+
+    context: Dict[str, Dict[str, object]] = {}
+    for file in sorted(root.rglob("*.py")):
+        # Skip hidden directories except ``.aether``
+        if any(part.startswith(".") and part != ".aether" for part in file.relative_to(root).parts[:-1]):
+            continue
+        context[str(file.relative_to(root))] = extract_file_context(file)
+
+    out_dir = root / ".aether"
+    out_dir.mkdir(exist_ok=True)
+    out = output_path or (out_dir / "context_map.json")
+    with out.open("w", encoding="utf-8") as fh:
+        json.dump(context, fh, indent=2, sort_keys=True)
+    return context
+
+
+__all__ = ["extract_file_context", "build_context_map"]

--- a/tests/test_code_context.py
+++ b/tests/test_code_context.py
@@ -1,0 +1,33 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure package root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from aether.code_context import build_context_map
+
+
+def test_build_context_map(tmp_path):
+    src = tmp_path / "example.py"
+    src.write_text(
+        '"""Example module."""\n\n'
+        'def greet(name):\n    """Say hello."""\n    print("hello", name)\n',
+        encoding="utf-8",
+    )
+
+    context = build_context_map(tmp_path)
+
+    assert "example.py" in context
+    assert context["example.py"]["summary"] == "Example module."
+
+    greet = context["example.py"]["functions"]["greet"]
+    assert greet["docstring"] == "Say hello."
+    assert greet["calls"] == ["print"]
+    assert greet["lines"] == 3
+
+    saved = tmp_path / ".aether" / "context_map.json"
+    assert saved.exists()
+    with saved.open("r", encoding="utf-8") as fh:
+        saved_data = json.load(fh)
+    assert saved_data == context


### PR DESCRIPTION
## Summary
- add `code_context` module to extract docstrings, function calls, and line counts for Python files
- output context mapping to `.aether/context_map.json`
- test building a context map from a sample module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e1f3183b883338c07972eb6d27906